### PR TITLE
Remove colon from scheduling labels

### DIFF
--- a/labels/labels.go
+++ b/labels/labels.go
@@ -10,6 +10,7 @@ const (
 	DeploymentUuidLabel = "io.rancher.deployment.uuid"
 	ContainerUuidLabel  = "io.rancher.container.uuid"
 
+	SchedulingLabelPrefix          = "io.rancher.scheduler"
 	GlobalLabel                    = "io.rancher.scheduler.global"
 	HostAffinityLabel              = "io.rancher.scheduler.affinity:host_label"
 	HostAntiAffinityLabel          = "io.rancher.scheduler.affinity:host_label_ne"

--- a/sync/podfromdu.go
+++ b/sync/podfromdu.go
@@ -100,25 +100,25 @@ func getAnnotations(deploymentUnit client.DeploymentSyncRequest) map[string]stri
 	annotations := map[string]string{}
 
 	for k, v := range primary.Labels {
-		if k != labels.ServiceLaunchConfig {
-			annotations[k] = fmt.Sprint(v)
-			annotations[getAnnotationName(primary.Name, k)] = fmt.Sprint(v)
-		}
+		annotations[getAnnotationName(primary.Name, k, true)] = fmt.Sprint(v)
 	}
 
 	for _, container := range deploymentUnit.Containers {
-		if container.Name == primary.Name {
-			continue
-		}
 		for k, v := range container.Labels {
-			annotations[getAnnotationName(container.Name, k)] = fmt.Sprint(v)
+			annotations[getAnnotationName(container.Name, k, false)] = fmt.Sprint(v)
 		}
 	}
 
 	return annotations
 }
 
-func getAnnotationName(containerName, label string) string {
+func getAnnotationName(containerName, label string, primary bool) string {
+	if strings.Contains(label, labels.SchedulingLabelPrefix) {
+		label = strings.Replace(label, ":", ".", -1)
+	}
+	if primary {
+		return label
+	}
 	return fmt.Sprintf("%s/%s", transformContainerName(containerName), label)
 }
 

--- a/sync/podfromdu_test.go
+++ b/sync/podfromdu_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"testing"
 
+	"fmt"
 	"github.com/rancher/go-rancher/v3"
 	"github.com/rancher/netes-agent/labels"
 	"github.com/rancher/netes-agent/utils"
@@ -39,8 +40,10 @@ func TestGetAnnotations(t *testing.T) {
 			},
 		},
 	}), map[string]string{
-		"a":    "b",
+		"a": "b",
+		labels.ServiceLaunchConfig: labels.ServicePrimaryLaunchConfig,
 		"c1/a": "b",
+		fmt.Sprintf("%s/%s", "c1", labels.ServiceLaunchConfig): labels.ServicePrimaryLaunchConfig,
 		"c2/c": "d",
 	})
 }

--- a/sync/responsefrompod.go
+++ b/sync/responsefrompod.go
@@ -14,7 +14,8 @@ func responseFromPod(pod v1.Pod) client.DeploymentSyncResponse {
 			continue
 		}
 
-		containerUuid, ok := pod.Annotations[getAnnotationName(containerStatus.Name, labels.ContainerUuidLabel)]
+		annotationName := getAnnotationName(containerStatus.Name, labels.ContainerUuidLabel, false)
+		containerUuid, ok := pod.Annotations[annotationName]
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
Annotations can't contain colons, so replace these with a period in the case of scheduling labels. A more general solution can be added later.